### PR TITLE
Add custom theme leveraging IMEI checker styles

### DIFF
--- a/wp-content/themes/UnlockSureIMEI/footer.php
+++ b/wp-content/themes/UnlockSureIMEI/footer.php
@@ -1,0 +1,10 @@
+</main>
+<footer class="site-footer" style="margin-top:48px;padding:24px 20px;background:#fff;border-top:1px solid #eee;">
+  <div style="max-width:1140px;margin:0 auto;display:flex;justify-content:space-between;align-items:center;">
+    <small>© <?php echo date('Y'); ?> UnlockSure — SIM unlocking made simple.</small>
+    <nav><?php wp_nav_menu(['theme_location'=>'footer','container'=>false]); ?></nav>
+  </div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/UnlockSureIMEI/functions.php
+++ b/wp-content/themes/UnlockSureIMEI/functions.php
@@ -1,0 +1,27 @@
+<?php
+// Enqueue brand fonts & base styles
+add_action('wp_enqueue_scripts', function() {
+  // Google Fonts (swap for local if needed)
+  wp_enqueue_style('unlocksure-fonts', 'https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&family=Open+Sans:wght@400;600&display=swap', [], null);
+  wp_enqueue_style('unlocksure-style', get_stylesheet_uri(), [], wp_get_theme()->get('Version'));
+});
+
+// WooCommerce support
+add_action('after_setup_theme', function(){
+  add_theme_support('woocommerce');
+});
+
+// Elementor container width (optional)
+add_filter('elementor/frontend/container_width', fn($w)=>1140);
+
+// Color palette in Gutenberg (optional)
+add_action('after_setup_theme', function(){
+  add_theme_support('editor-color-palette', [
+    ['name'=>'Blue','slug'=>'us-blue','color'=>'#0073E6'],
+    ['name'=>'Navy','slug'=>'us-navy','color'=>'#1A1A2E'],
+    ['name'=>'Gray','slug'=>'us-gray','color'=>'#F5F7FA'],
+    ['name'=>'Mid Gray','slug'=>'us-mgray','color'=>'#A0A4A8'],
+    ['name'=>'Orange','slug'=>'us-orange','color'=>'#FF6F3C'],
+    ['name'=>'Error','slug'=>'us-error','color'=>'#E74C3C'],
+  ]);
+});

--- a/wp-content/themes/UnlockSureIMEI/header.php
+++ b/wp-content/themes/UnlockSureIMEI/header.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo('charset'); ?>">
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header class="site-header" style="background:#fff; border-bottom:1px solid #eee;">
+  <div class="container" style="max-width:1140px;margin:0 auto;padding:12px 20px;display:flex;align-items:center;gap:16px;">
+    <a href="<?php echo esc_url(home_url('/')); ?>" class="logo" style="font-weight:700;color:#1A1A2E;text-decoration:none;">UnlockSure</a>
+    <?php wp_nav_menu(['theme_location'=>'primary','container'=>false]); ?>
+  </div>
+</header>
+<main class="site-main" style="max-width:1140px;margin:24px auto;padding:0 20px;">

--- a/wp-content/themes/UnlockSureIMEI/index.php
+++ b/wp-content/themes/UnlockSureIMEI/index.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<?php if (have_posts()) : while (have_posts()) : the_post(); ?>
+  <article <?php post_class(); ?>>
+    <h1><?php the_title(); ?></h1>
+    <div class="entry"><?php the_content(); ?></div>
+  </article>
+<?php endwhile; endif; ?>
+<?php get_footer(); ?>

--- a/wp-content/themes/UnlockSureIMEI/style.css
+++ b/wp-content/themes/UnlockSureIMEI/style.css
@@ -1,0 +1,39 @@
+/*
+Theme Name: UnlockSure IMEI Theme
+Author: UnlockSure
+Version: 0.1.0
+Text Domain: unlocksure-imei-theme
+*/
+
+/* Import IMEI checker styles for consistent branding */
+@import url("../plugins/unlocksure-imei/assets/unlocksure-imei.css");
+
+:root{
+  --us-blue:#0073E6;
+  --us-navy:#1A1A2E;
+  --us-gray:#F5F7FA;
+  --us-mgray:#A0A4A8;
+  --us-orange:#FF6F3C;
+  --us-error:#E74C3C;
+}
+
+body{
+  font-family: "Open Sans", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  background: var(--us-gray);
+  color:#222;
+}
+
+a.button, button, .button{
+  border-radius:12px;
+  background-image: linear-gradient(180deg, var(--us-blue) 0%, var(--us-blue) 100%);
+  color:#fff; padding:12px 18px; text-decoration:none; display:inline-block;
+}
+a.button:hover, button:hover, .button:hover{
+  background-image: linear-gradient(180deg, var(--us-orange) 0%, var(--us-orange) 100%);
+}
+
+h1,h2,h3,.elementor-heading-title{
+  font-family:"Montserrat", "MontserratLocal", Arial, sans-serif;
+  font-weight:700;
+  color:var(--us-navy);
+}


### PR DESCRIPTION
## Summary
- add UnlockSure IMEI Theme that imports the plugin's IMEI checker stylesheet for consistent branding

## Testing
- `php -l wp-content/themes/UnlockSureIMEI/functions.php`
- `php -l wp-content/themes/UnlockSureIMEI/header.php`
- `php -l wp-content/themes/UnlockSureIMEI/footer.php`
- `php -l wp-content/themes/UnlockSureIMEI/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0a56010008326a2d5adf175abcca5